### PR TITLE
Added copying of Config folder during zipping up of the plugin

### DIFF
--- a/Plugins/PluginBuilder/Source/PluginBuilder/Private/PluginBuilder/Tasks/ZipUpPluginTask.cpp
+++ b/Plugins/PluginBuilder/Source/PluginBuilder/Private/PluginBuilder/Tasks/ZipUpPluginTask.cpp
@@ -39,6 +39,11 @@ namespace PluginBuilder
 				UE_LOG(LogPluginBuilder, Error, TEXT("Failed to copy uplugin file."));
 			}
 		}
+
+		if(!CopyPluginFilter())
+		{
+			UE_LOG(LogPluginBuilder, Warning, TEXT("Failed to copy Config folder."));
+		}
 		
 		const FString ZipTempDirectoryPath = GetZipTempDirectoryPath() / UATBatchFileParams.GetPluginNameInSpecifiedFormat();
 		
@@ -140,6 +145,20 @@ namespace PluginBuilder
 		return PlatformFile.CopyFile(
 			*OutputUPluginFile,
 			*OriginalUPluginFile
+		);
+	}
+
+	bool FZipUpPluginTask::CopyPluginFilter() const
+	{
+		const FString& OriginalConfigFolder = FPaths::GetPath(UATBatchFileParams.UPluginFile) / TEXT("Config");
+		const FString& OutputConfigFolder = (GetBuiltPluginDestinationPath() / TEXT("Config"));
+
+		IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+		
+		return PlatformFile.CopyDirectoryTree(
+			*OutputConfigFolder,
+			*OriginalConfigFolder,
+			true
 		);
 	}
 }

--- a/Plugins/PluginBuilder/Source/PluginBuilder/Private/PluginBuilder/Tasks/ZipUpPluginTask.h
+++ b/Plugins/PluginBuilder/Source/PluginBuilder/Private/PluginBuilder/Tasks/ZipUpPluginTask.h
@@ -35,6 +35,8 @@ namespace PluginBuilder
 		// Copies the properties of the original uplugin file to the UAT output uplugin file.
 		bool CopyUPluginProperties() const;
 
+		// Copies the config folder from the original plugin to the UAT output.
+		bool CopyPluginFilter() const;
 	private:
 		// The dataset used to process plugin zip up.
 		FZipUpPluginParams ZipUpPluginParams;


### PR DESCRIPTION
Marketplace requires that FilterPlugin.ini be in the uploaded package when submitting a code plugin, however the UAT does not seem to package that folder when building a plugin. To avoid having to manually unzip and copy over the config folder to each built plugin, i had added functionality to do it automatically during zipping up of the plugin.